### PR TITLE
Backgound images on touch devices

### DIFF
--- a/_sass/callout.scss
+++ b/_sass/callout.scss
@@ -7,6 +7,10 @@
   background-size: cover;
   background-attachment: fixed;
 
+  @include touch_device {
+    background-attachment: scroll;
+  }
+
   &__header {
     margin-bottom: 2rem;
   }

--- a/_sass/defence.scss
+++ b/_sass/defence.scss
@@ -505,11 +505,16 @@
     background-position: center;
     background-attachment: fixed;
 
+    
     background-image: var(--contact-bg-image);
-
+    
     background-color: var(--contact-bg-color);
-
+    
     color: $light;
+    
+    @include touch_device {
+      background-attachment: scroll;
+    }
 
     @include breakpoint(small) {
       background-image: none;

--- a/_sass/footer.scss
+++ b/_sass/footer.scss
@@ -26,12 +26,15 @@
     &--2 {
       grid-template-columns: 50% 1fr;
 
+      gap: 2rem;
+
       @include breakpoint(medium) {
         grid-template-columns: 300px 1fr;
       }
 
       @include breakpoint(small) {
         grid-template-columns: repeat(1, minmax(0, 1fr));
+        gap: 1rem;
       }
     }
 

--- a/_sass/hero.scss
+++ b/_sass/hero.scss
@@ -12,6 +12,10 @@
   background-size: cover;
   background-attachment: fixed;
 
+  @include touch_device {
+    background-attachment: scroll;
+  }
+
   & > .container {
     padding-top: 12rem;
 

--- a/_sass/vars.scss
+++ b/_sass/vars.scss
@@ -36,6 +36,14 @@ $zinc: #3f3f46;
   }
 }
 
+@mixin touch_device {
+  @media (any-pointer: coarse) and (any-hover: none) {
+    @media not all and (any-pointer: fine) {
+      @content;
+    }
+  }
+}
+
 @mixin mobile_btn($display: block) {
   @include breakpoint(smaller) {
     display: $display;

--- a/_sass/why.scss
+++ b/_sass/why.scss
@@ -9,6 +9,10 @@
   background-color: rgba(255, 255, 255, 0.7);
   background-blend-mode: lighten;
 
+  @include touch_device {
+    background-attachment: scroll;
+  }
+
   &__img-wrapper {
     @include breakpoint(small) {
       max-width: 500px;


### PR DESCRIPTION
There is an issue on iOS browsers; they do not support fixed positioned background images.

There are workarounds, but the the user experience is not ideal. So for mobile devices (touch devices to be accurate).

With this PR, the background images just scroll along with the rest of the page.

Bonus: fixed the footer social icons alignment.